### PR TITLE
Fix issue with custom showing 2 imenu-list groups

### DIFF
--- a/imenu-list.el
+++ b/imenu-list.el
@@ -637,7 +637,7 @@ ARG is ignored."
 
 ;;;###autoload
 (define-minor-mode imenu-list-minor-mode
-  nil :global t
+  nil :global t :group 'imenu-list
   (if imenu-list-minor-mode
       (progn
         (imenu-list-get-buffer-create)


### PR DESCRIPTION
The minor-mode definition currently doesn't have a custom group defined, which will result in creating an extra group called imenu-list-minor, I don't believe that's what you want, so here's the fix.