### PR TITLE
Fix package-lint/byte-compier/checkdoc warnings

### DIFF
--- a/imenu-list.el
+++ b/imenu-list.el
@@ -5,7 +5,7 @@
 ;; Author: Bar Magal (2015)
 ;; Version: 0.8
 ;; Homepage: https://github.com/bmag/imenu-list
-;; Package-Requires: ((cl-lib "0.5") (emacs "24.3"))
+;; Package-Requires: ((emacs "24.3"))
 
 ;; This file is not part of GNU Emacs.
 

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -4,6 +4,7 @@
 
 ;; Author: Bar Magal (2015)
 ;; Version: 0.8
+;; Keywords: tools imenu
 ;; Homepage: https://github.com/bmag/imenu-list
 ;; Package-Requires: ((emacs "24.3"))
 

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -45,6 +45,7 @@
 
 (require 'imenu)
 (require 'cl-lib)
+(require 'hideshow)
 
 (defconst imenu-list-buffer-name "*Ilist*"
   "Name of the buffer that is used to display imenu entries.")

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -242,8 +242,7 @@ See `hs-minor-mode' for information on what is hide/show."
                                           (car entry))
                        'follow-link t
                        'action ;; #'imenu-list--action-goto-entry
-                       #'imenu-list--action-toggle-hs
-                       )
+                       #'imenu-list--action-toggle-hs)
         (insert "\n"))
     (insert (imenu-list--depth-string depth))
     (insert-button (format "%s" (car entry))

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -80,7 +80,8 @@ Used to avoid updating if the point didn't move.")
   "Local mode-line format for the imenu-list buffer.
 This is the local value of `mode-line-format' to use in the imenu-list
 buffer.  See `mode-line-format' for allowed values."
-  :group 'imenu-list)
+  :group 'imenu-list
+  :type 'sexp)
 
 (defcustom imenu-list-focus-after-activation nil
   "Non-nil to select the imenu-list window automatically when

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -383,7 +383,7 @@ Either a positive integer (number of rows/columns) or a percentage."
 
 (defcustom imenu-list-position 'right
   "Position of the imenu-list buffer.
-Either 'right, 'left, 'above or 'below. This value is passed directly to
+Either 'right, 'left, 'above or 'below.  This value is passed directly to
 `split-window'."
   :group 'imenu-list
   :type '(choice (const above)
@@ -393,7 +393,7 @@ Either 'right, 'left, 'above or 'below. This value is passed directly to
 
 (defcustom imenu-list-auto-resize nil
   "If non-nil, auto-resize window after updating the imenu-list buffer.
-Resizing the width works only for emacs 24.4 and newer.  Resizing the
+Resizing the width works only for Emacs 24.4 and newer.  Resizing the
 height doesn't suffer that limitation."
   :group 'imenu-list
   :type 'boolean)

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -481,33 +481,33 @@ Oherwise `imenu-list-update' will return the error that has occured, as
 If FORCE-UPDATE is non-nil, the imenu-list buffer is updated even if the
 imenu entries did not change since the last update."
   (catch 'index-failure
-      (let ((old-entries imenu-list--imenu-entries)
-            (location (point-marker)))
-        ;; don't update if `point' didn't move - fixes issue #11
-        (unless (and (null force-update)
-                     imenu-list--last-location
-                     (marker-buffer imenu-list--last-location)
-                     (= location imenu-list--last-location))
-          (setq imenu-list--last-location location)
-          (if raise-imenu-errors
+    (let ((old-entries imenu-list--imenu-entries)
+          (location (point-marker)))
+      ;; don't update if `point' didn't move - fixes issue #11
+      (unless (and (null force-update)
+                   imenu-list--last-location
+                   (marker-buffer imenu-list--last-location)
+                   (= location imenu-list--last-location))
+        (setq imenu-list--last-location location)
+        (if raise-imenu-errors
+            (imenu-list-collect-entries)
+          (condition-case err
               (imenu-list-collect-entries)
-            (condition-case err
-                (imenu-list-collect-entries)
-              (error
-               (message "imenu-list: couldn't create index because of error: %S" err)
-               (throw 'index-failure err))))
-          (when (or force-update
-                    ;; check if Ilist buffer is alive, in case it was killed
-                    ;; since last update
-                    (null (get-buffer imenu-list-buffer-name))
-                    (not (equal old-entries imenu-list--imenu-entries)))
-            (with-current-buffer (imenu-list-get-buffer-create)
-              (imenu-list-insert-entries)))
-          (imenu-list--show-current-entry)
-          (when imenu-list-auto-resize
-            (imenu-list-resize-window))
-          (run-hooks 'imenu-list-update-hook)
-          nil))))
+            (error
+             (message "imenu-list: couldn't create index because of error: %S" err)
+             (throw 'index-failure err))))
+        (when (or force-update
+                  ;; check if Ilist buffer is alive, in case it was killed
+                  ;; since last update
+                  (null (get-buffer imenu-list-buffer-name))
+                  (not (equal old-entries imenu-list--imenu-entries)))
+          (with-current-buffer (imenu-list-get-buffer-create)
+            (imenu-list-insert-entries)))
+        (imenu-list--show-current-entry)
+        (when imenu-list-auto-resize
+          (imenu-list-resize-window))
+        (run-hooks 'imenu-list-update-hook)
+        nil))))
 
 (defun imenu-list-refresh ()
   "Refresh imenu-list buffer."

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -442,6 +442,8 @@ See `purpose-special-action-sequences' for a description of _PURPOSE,
 BUFFER and _ALIST."
   (string-equal (buffer-name buffer) imenu-list-buffer-name))
 
+(defvar purpose-special-action-sequences)
+
 (defun imenu-list-install-purpose-display ()
   "Install imenu-list display settings for window-purpose.
 Install entry for imenu-list in `purpose-special-action-sequences'."

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -5,7 +5,7 @@
 ;; Author: Bar Magal (2015)
 ;; Version: 0.8
 ;; Homepage: https://github.com/bmag/imenu-list
-;; Package-Requires: ((cl-lib "0.5"))
+;; Package-Requires: ((cl-lib "0.5") (emacs "24.3"))
 
 ;; This file is not part of GNU Emacs.
 

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -626,12 +626,14 @@ ARG is ignored."
            (when imenu-list--timer (imenu-list-start-timer)))))
 
 (defun imenu-list-start-timer ()
+  "Start idle timer for invoking `imenu-list-update-safe'."
   (imenu-list-stop-timer)
   (setq imenu-list--timer
         (run-with-idle-timer imenu-list-idle-update-delay t
                              #'imenu-list-update-safe)))
 
 (defun imenu-list-stop-timer ()
+  "Stop idle timer for invoking `imenu-list-update-safe'."
   (when imenu-list--timer
     (cancel-timer imenu-list--timer)
     (setq imenu-list--timer nil)))

--- a/imenu-list.el
+++ b/imenu-list.el
@@ -468,6 +468,7 @@ If it doesn't exist, create it."
           buffer))))
 
 (defun imenu-list-resize-window ()
+  "Resize imenu-list window."
   (let ((fit-window-to-buffer-horizontally t))
     (mapc #'fit-window-to-buffer
           (get-buffer-window-list (imenu-list-get-buffer-create)))))


### PR DESCRIPTION
Hi!
I found this package, I fix some of linter warnings for my first contribution step!

### before
```elisp
 imenu-li…    53     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 imenu-li…    74   1 warning         defcustom for ‘imenu-list-mode-line-format’ fails to specify type (emacs-lisp)
 imenu-li…    74   1 warning         defcustom for ‘imenu-list-mode-line-format’ fails to specify type (emacs-lisp)
 imenu-l…    86     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 imenu-l…   385     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 imenu-l…   395     warning         Name emacs should appear capitalized as Emacs (emacs-lisp-checkdoc)
 imenu-l…   447  15 warning         reference to free variable ‘purpose-special-action-sequences’ (emacs-lisp)
 imenu-l…   447  15 warning         assignment to free variable ‘purpose-special-action-sequences’ (emacs-lisp)
 imenu-l…   467     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 imenu-l…   484     warning         Indent mismatch (indent-elisp)
 imenu-l…   485     warning         Indent mismatch (indent-elisp)
 imenu-l…   486     warning         Indent mismatch (indent-elisp)
 imenu-l…   487     warning         Indent mismatch (indent-elisp)
 imenu-l…   488     warning         Indent mismatch (indent-elisp)
 imenu-l…   489     warning         Indent mismatch (indent-elisp)
 imenu-l…   490     warning         Indent mismatch (indent-elisp)
 imenu-l…   491     warning         Indent mismatch (indent-elisp)
 imenu-l…   492     warning         Indent mismatch (indent-elisp)
 imenu-l…   493     warning         Indent mismatch (indent-elisp)
 imenu-l…   494     warning         Indent mismatch (indent-elisp)
 imenu-l…   495     warning         Indent mismatch (indent-elisp)
 imenu-l…   496     warning         Indent mismatch (indent-elisp)
 imenu-l…   497     warning         Indent mismatch (indent-elisp)
 imenu-l…   498     warning         Indent mismatch (indent-elisp)
 imenu-l…   499     warning         Indent mismatch (indent-elisp)
 imenu-l…   500     warning         Indent mismatch (indent-elisp)
 imenu-l…   501     warning         Indent mismatch (indent-elisp)
 imenu-l…   502     warning         Indent mismatch (indent-elisp)
 imenu-l…   503     warning         Indent mismatch (indent-elisp)
 imenu-l…   504     warning         Indent mismatch (indent-elisp)
 imenu-l…   505     warning         Indent mismatch (indent-elisp)
 imenu-l…   506     warning         Indent mismatch (indent-elisp)
 imenu-l…   507     warning         Indent mismatch (indent-elisp)
 imenu-l…   508     warning         Indent mismatch (indent-elisp)
 imenu-l…   509     warning         Indent mismatch (indent-elisp)
 imenu-l…   510     warning         Indent mismatch (indent-elisp)
 imenu-l…   628     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 imenu-l…   634     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 imenu-l…   676   1 warning         the function ‘hs-toggle-hiding’ is not known to be defined. (emacs-lisp)
```

### after
```elisp
 imenu-li…    54     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 imenu-li…    88     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
```