### PR TITLE
Speed up list entry insertion by 66%

### DIFF
--- a/imenu-list.el
+++ b/imenu-list.el
@@ -257,7 +257,7 @@ DEPTH is the depth of the code block were the entries are written.
 Each entry is inserted in its own line.
 Each entry is appended to `imenu-list--line-entries' as well."
   (dolist (entry index-alist)
-    (setq imenu-list--line-entries (append imenu-list--line-entries (list entry)))
+    (setq imenu-list--line-entries (cons entry imenu-list--line-entries))
     (imenu-list--insert-entry entry depth)
     (when (imenu--subalist-p entry)
       (imenu-list--insert-entries-internal (cdr entry) (1+ depth)))))
@@ -273,6 +273,7 @@ function)."
   (erase-buffer)
   (setq imenu-list--line-entries nil)
   (imenu-list--insert-entries-internal imenu-list--imenu-entries 0)
+  (setq imenu-list--line-entries (nreverse imenu-list--line-entries))
   (read-only-mode 1))
 
 


### PR DESCRIPTION
For huge files with lots of entries, that `append` call is very inefficient as it just keeps linear searching to the end of a longer and longer list and triggering massive GCs. This implementation cuts down the time to construct the line entries to 1/3 the current implementation. I've tested this with a 37k lines of JSON with lsp-eslint, which pretty much generates an entry per line. Before took about 111s, after took about 34s.