### PR TITLE
Fix #79 imenu-list update when same position, but different buffer

### DIFF
--- a/imenu-list.el
+++ b/imenu-list.el
@@ -539,7 +539,7 @@ imenu entries did not change since the last update."
       (unless (and (null force-update)
                    imenu-list--last-location
                    (marker-buffer imenu-list--last-location)
-                   (= location imenu-list--last-location))
+                   (equal location imenu-list--last-location))
         (setq imenu-list--last-location location)
         (condition-case err
             (imenu-list-collect-entries)


### PR DESCRIPTION
Fix #79 
The cause is comparing the new location and the last location as an integer by `=`.

https://www.gnu.org/software/emacs/manual/html_node/elisp/Overview-of-Markers.html
> A marker can be used to represent a position in functions that require one, just as an integer could be used. In that case, the marker’s buffer is normally ignored. 

so, it's compared with position only, but we should compare with position and buffer so that we update it when the buffer is changed, using equal