### PR TITLE
Fix 2 byte compiling warnings in Emacs 29.3

### DIFF
--- a/imenu-list.el
+++ b/imenu-list.el
@@ -436,7 +436,7 @@ Either a positive integer (number of rows/columns) or a percentage."
 
 (defcustom imenu-list-position 'right
   "Position of the imenu-list buffer.
-Either 'right, 'left, 'above or 'below.  This value is passed
+Either `right', `left', `above` or `below'.  This value is passed
 directly to `split-window'."
   :group 'imenu-list
   :type '(choice (const above)
@@ -663,7 +663,7 @@ ARG is ignored."
     (forward-char))
   ;; (when (= (char-after) ?+)
   ;;   (forward-char 2))
-  (let ((spaces (- (point) (point-at-bol))))
+  (let ((spaces (- (point) (line-beginning-position))))
     (forward-line)
     ;; ignore-errors in case we're at the last line
     (ignore-errors (forward-char spaces))


### PR DESCRIPTION
Currently imenu-list results 2 byte compiling warnings in Emacs 29.
```
imenu-list.el:437:2: Warning: custom-declare-variable `imenu-list-position'
    docstring has wrong usage of unescaped single quotes (use \= or different
    quoting)

imenu-list.el:666:29: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
```

```
P.s. Using `right' to render ‘right’, just like the docstring in split-window.
```